### PR TITLE
[ON-43] 기사 본문 크롤링 로직 구현

### DIFF
--- a/airflow/dags/libs/news_article/crawler/contentCrawling.py
+++ b/airflow/dags/libs/news_article/crawler/contentCrawling.py
@@ -110,6 +110,6 @@ def build_content_df(urls):
 
 
 # 테스트
-urls = ["https://www.itworld.co.kr/article/4050262", "https://www.itworld.co.kr/article/4050189"]
-df = build_content_df(urls)
-df.to_csv("test.csv", index=False, encoding="utf-8-sig")
+# urls = ["https://www.itworld.co.kr/article/4050262", "https://www.itworld.co.kr/article/4050189"]
+# df = build_content_df(urls)
+# df.to_csv("test.csv", index=False, encoding="utf-8-sig")

--- a/airflow/dags/libs/news_article/crawler/contentCrawling.py
+++ b/airflow/dags/libs/news_article/crawler/contentCrawling.py
@@ -7,8 +7,8 @@ import re
 import random
 
 def get_content(url):
-    r = requests.get(url)
-    time.sleep(random.randint(1,3))
+    time.sleep(random.uniform(1.0, 3.0))
+    r = requests.get(url, timeout=(5, 15))
     r.raise_for_status()
     soup = BeautifulSoup(r.text, "html.parser")
 
@@ -82,7 +82,7 @@ def get_content(url):
                 # 라스트 flush
 
     if not sub_col:
-        sub_col, content_col = ["nosubtitle"], [""]
+        sub_col, content_col = ["nosubtitle"], [[]]
 
     return {
         "url": url,
@@ -110,6 +110,6 @@ def build_content_df(urls):
 
 
 # 테스트
-# urls = ["https://www.itworld.co.kr/article/4050262", "https://www.itworld.co.kr/article/4050189"]
-# df = build_content_df(urls)
-# df.to_csv("test.csv", index=False, encoding="utf-8-sig")
+urls = ["https://www.itworld.co.kr/article/4050262", "https://www.itworld.co.kr/article/4050189"]
+df = build_content_df(urls)
+df.to_csv("test.csv", index=False, encoding="utf-8-sig")

--- a/airflow/dags/libs/news_article/crawler/contentCrawling.py
+++ b/airflow/dags/libs/news_article/crawler/contentCrawling.py
@@ -1,0 +1,115 @@
+from bs4 import BeautifulSoup
+import requests
+import time
+import pandas as pd
+import numpy as np
+import re
+import random
+
+def get_content(url):
+    r = requests.get(url)
+    time.sleep(random.randint(1,3))
+    r.raise_for_status()
+    soup = BeautifulSoup(r.text, "html.parser")
+
+    # 제목
+    title_el = soup.find("h1", {"class": re.compile(r"article-hero__title")}) or soup.find("h1")
+    title = title_el.get_text(strip=True) if title_el else ""
+
+    # 태그
+    tags_div = soup.find("div", {"class": re.compile(r"card__tags")})
+    tags = [a.get_text(strip=True) for a in tags_div.find_all("a")] if tags_div else []
+
+    # 발행일
+    publish_time = ""
+    t = soup.find("time")
+    if t:
+        publish_time = t.get_text(strip=True)
+    if not publish_time:
+        m = re.search(r"\b(\d{4}\.\d{2}\.\d{2})\b", soup.get_text(" ", strip=True))
+        if m:
+            publish_time = m.group(1)
+
+    # 작성자
+    author = ""
+    a_prof = soup.find("a", href=re.compile(r"/profile/"))
+    if a_prof:
+        author = a_prof.get_text(strip=True)
+    if not author:
+        full_text = soup.get_text("\n", strip=True)
+        m = re.search(r"\bBy\s+([^\n|]+)", full_text)
+        if m:
+            author = m.group(1).strip()
+
+    # 본문 섹션
+        # 섹션 제목: h2
+        # 본문 문단: p
+    content_divs = soup.find_all("div", {"class": re.compile(r"article-column__content")})
+    sub_col, content_col = [], []
+    current_sub, current_paras = "nosubtitle", []
+
+    # 문단 묶기
+    # 문단들을 하나의 소제목 그룹으로 저장하기 위한 작업
+    def flush():
+        if current_paras:
+            sub_col.append(current_sub)
+            content_col.append(current_paras[:])
+
+    # 첫 문단을 h2태그에 쓰는 경우 확인
+    # 해당 h2태그가 소제목일지, 문단일지 구분할 필요 있음
+    def looks_like_paragraph(text):
+        text = text.strip()
+        return (len(text) >= 60) or (text[-1:] in [".","!","?","…","다","요"])
+
+    # div(h2/p) 순회
+    for div in content_divs:
+        for tag in div.find_all(["h2","p"]):
+            text = tag.get_text(strip=True)
+            if not text:    # 내용 없으면 넘기기
+                continue
+            if tag.name == "h2":    # 소제목인 경우
+                if not sub_col and current_sub == "nosubtitle" and not current_paras and looks_like_paragraph(text):
+                    current_paras.append(text)
+                    continue
+                flush()     # 지금까지 모은 문단들 하나의 섹션으로 확정
+                current_sub = text  # 새로운 소제목 시작
+                current_paras = []
+            else:  # 일반 문단일 경우
+                current_paras.append(text)
+    
+    
+    flush()     # 반복 이후에도 마지막 소제목 밑에 문단 남아있을 수 있음
+                # 라스트 flush
+
+    if not sub_col:
+        sub_col, content_col = ["nosubtitle"], [""]
+
+    return {
+        "url": url,
+        "title": title,
+        "tags": tags,
+        "publish_time": publish_time,
+        "author": author,
+        "sub_col": sub_col,
+        "content_col": content_col,
+    }
+
+# 여러 기사 url 리스트 받아서 DataFrame으로 확인
+def build_content_df(urls):
+    rows = []
+    for u in urls:
+        try:
+            rows.append(get_content(u))
+        except Exception as e:
+            print(f"{u} -> {e}")
+            pass
+    return pd.DataFrame(
+        rows, 
+        columns=["url","title","tags","publish_time","author","sub_col","content_col"]
+        )
+
+
+# 테스트
+# urls = ["https://www.itworld.co.kr/article/4050262", "https://www.itworld.co.kr/article/4050189"]
+# df = build_content_df(urls)
+# df.to_csv("test.csv", index=False, encoding="utf-8-sig")

--- a/airflow/dags/libs/news_article/crawler/contentCrawling.py
+++ b/airflow/dags/libs/news_article/crawler/contentCrawling.py
@@ -102,7 +102,7 @@ def build_content_df(urls):
             rows.append(get_content(u))
         except Exception as e:
             print(f"{u} -> {e}")
-            pass
+            raise
     return pd.DataFrame(
         rows, 
         columns=["url","title","tags","publish_time","author","sub_col","content_col"]


### PR DESCRIPTION
## 📌 개요
<!-- PR의 목적을 간단히 설명해주세요. -->
ITWorld 기사 본문 크롤링 기능을 추가했습니다.
url 리스트를 넘겨받는다는 전제 하에, 제목/태그/발행일/작성자/본문을 수집합니다.

## ✨ 주요 변경 사항
<!-- PR의 주요 변경 사항을 작성해주세요. -->
- [x] get_content(url) 함수 구현
  - 제목, 태그, 기사 날짜, 작성자 추출
  - 본문을 소제목-문단 기준으로 섹션화
  - 일부 기사에서 첫 문단이 h2 태그에 포함되는 케이스 반영
- [x] build_content_df(urls) 함수 구현
  - url 리스트 입력 시 결과 값 데이터프레임으로 반환

## 🔍 관련 이슈
<!-- Jira 발행 티겟을 입력해주세요. -->
- [ON-43](https://yuwolxx.atlassian.net/browse/ON-43?atlOrigin=eyJpIjoiNmIwNjczZjI0YmJhNGVhZGFjZjJjN2FmMTdhOGRmNmMiLCJwIjoiaiJ9)

## 🙏 To Reviewers
<!-- 코드 이해를 위해 참고할 수 있는 자료나 팀원에게 전달할 내용 입력해주세요. -->
- 요청 헤더를 추가했을 때 일부 환경에서 정상적으로 동작하지 않는 경우가 있어, 헤더를 제거한 상태로 동작을 확인했습니다.
- 본문은 `sub_col`(소제목)과 `content_col`(문단 리스트) 구조로 분리하였으니, 이 부분을 중점적으로 확인 부탁드립니다!

## 🔗 문서
<!-- 참고할 수 있는 자료(노션 정리 또는 공식 문서 등)를 입력하세요. -->
- [BeautifulSoup 공식문서](https://www.crummy.com/software/BeautifulSoup/bs4/doc/)
- [Requests 공식문서](https://requests.readthedocs.io/en/latest/)
- [ITWorld](https://www.itworld.co.kr/)

## 🧪 테스트 방법
1. urls 리스트에 기사 URL을 넣어주세요
2. 마지막 3줄(urls ~ df.to_csv(...))의 주석을 해제하면 test.csv 파일이 생성됩니다
3. test.csv를 열어 제목·태그·발행일·작성자·본문 섹션이 잘 저장되는지 확인할 수 있습니다



[ON-43]: https://yuwolxx.atlassian.net/browse/ON-43?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a news-article crawler with polite request throttling and robust fetching.
  * Automatically extracts title, tags, publish date, author, and structured content (subheadings and paragraphs).
  * Uses multiple fallback patterns to handle varied page layouts and missing fields.
  * Supports batch processing of multiple URLs and returns a structured dataset.
  * Surfaces per-URL errors clearly during batch runs and includes example usage for building datasets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->