### PR TITLE
[ON-55] DAG 기본 구조 설계 및 스켈레톤 추가

### DIFF
--- a/airflow/dags/news_crawling_to_db_dag.py
+++ b/airflow/dags/news_crawling_to_db_dag.py
@@ -1,0 +1,63 @@
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from airflow.operators.trigger_dagrun import TriggerDagRunOperator 
+from datetime import timedelta
+import pendulum
+
+tz = pendulum.timezone("Asia/Seoul")
+
+# 1. 기사 링크 크롤링
+def task_get_article_link(**context):
+    from libs.news_article.crawler.linkCrawling import get_article_link
+    article_links = get_article_link()
+    return article_links 
+
+# 2. 기사 본문 크롤링
+def task_build_content_df(**context):
+    from libs.news_article.crawler.contentCrawling import build_content_df
+    ti = context["ti"]
+    article_links = ti.xcom_pull(key="return_value", task_ids="get_article_link")
+    urls = [a["url"] for a in article_links]
+    content_df_records = build_content_df(urls)
+    return content_df_records 
+
+# 3. DB 반영
+def task_process_crawled_articles(**context):
+    from libs.news_article.db_update.article_db_handler import process_crawled_articles, get_db_connection
+    ti = context["ti"]
+    records = ti.xcom_pull(key="return_value", task_ids="build_content_df")
+    conn = get_db_connection()
+    process_crawled_articles(records, conn)
+
+default_args = {"owner": "airflow", "retries": 1, "retry_delay": timedelta(minutes=5)}
+
+with DAG(
+    dag_id="news_crawling_to_db_dag",
+    schedule_interval="0 7 * * *",
+    start_date=tz.datetime(2025, 9, 1, 7, 0),
+    catchup=False,
+    default_args=default_args,
+    timezone=tz,
+) as dag:
+    get_article_link_task = PythonOperator(
+        task_id="get_article_link",
+        python_callable=task_get_article_link,
+    )
+    build_content_df_task = PythonOperator(
+        task_id="build_content_df",
+        python_callable=task_build_content_df,
+    )
+    process_crawled_articles_task = PythonOperator(
+        task_id="process_crawled_articles",
+        python_callable=task_process_crawled_articles,
+    )
+
+    trigger_dag2 = TriggerDagRunOperator(
+            task_id="trigger_select_top5_and_save_dag",
+            trigger_dag_id="select_top5_and_save_dag",
+            reset_dag_run=True,              
+            wait_for_completion=False,               
+            conf={"source": "news_crawling_to_db_dag"},   
+        )
+
+    get_article_link_task >> build_content_df_task >> process_crawled_articles_task >> trigger_dag2

--- a/airflow/dags/news_crawling_to_db_dag.py
+++ b/airflow/dags/news_crawling_to_db_dag.py
@@ -1,63 +1,51 @@
 from airflow import DAG
 from airflow.operators.python import PythonOperator
-from airflow.operators.trigger_dagrun import TriggerDagRunOperator 
+from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 from datetime import timedelta
 import pendulum
 
 tz = pendulum.timezone("Asia/Seoul")
 
-# 1. 기사 링크 크롤링
-def task_get_article_link(**context):
+# 1) 링크 수집
+def task_get_article_links(**context):
     from libs.news_article.crawler.linkCrawling import get_article_link
-    article_links = get_article_link()
-    return article_links 
+    links = get_article_link()
+    return links
 
-# 2. 기사 본문 크롤링
-def task_build_content_df(**context):
-    from libs.news_article.crawler.contentCrawling import build_content_df
+# 2) Articles 테이블에 적재/업서트
+def task_upsert_articles(**context):
+    from libs.news_article.db_update.article_db_handler import get_db_connection, process_crawled_articles
     ti = context["ti"]
-    article_links = ti.xcom_pull(key="return_value", task_ids="get_article_link")
-    urls = [a["url"] for a in article_links]
-    content_df_records = build_content_df(urls)
-    return content_df_records 
-
-# 3. DB 반영
-def task_process_crawled_articles(**context):
-    from libs.news_article.db_update.article_db_handler import process_crawled_articles, get_db_connection
-    ti = context["ti"]
-    records = ti.xcom_pull(key="return_value", task_ids="build_content_df")
+    links = ti.xcom_pull(key="return_value", task_ids="get_article_links")
     conn = get_db_connection()
-    process_crawled_articles(records, conn)
+    process_crawled_articles(links)
 
 default_args = {"owner": "airflow", "retries": 1, "retry_delay": timedelta(minutes=5)}
 
 with DAG(
     dag_id="news_crawling_to_db_dag",
-    schedule_interval="0 7 * * *",
+    schedule="0 7 * * *",
     start_date=tz.datetime(2025, 9, 1, 7, 0),
     catchup=False,
     default_args=default_args,
     timezone=tz,
 ) as dag:
-    get_article_link_task = PythonOperator(
-        task_id="get_article_link",
-        python_callable=task_get_article_link,
+    get_article_links = PythonOperator(
+        task_id="get_article_links",
+        python_callable=task_get_article_links,
     )
-    build_content_df_task = PythonOperator(
-        task_id="build_content_df",
-        python_callable=task_build_content_df,
-    )
-    process_crawled_articles_task = PythonOperator(
-        task_id="process_crawled_articles",
-        python_callable=task_process_crawled_articles,
+
+    upsert_articles_task = PythonOperator(
+        task_id="upsert_articles",
+        python_callable=task_upsert_articles,
     )
 
     trigger_dag2 = TriggerDagRunOperator(
-            task_id="trigger_select_top5_and_save_dag",
-            trigger_dag_id="select_top5_and_save_dag",
-            reset_dag_run=True,              
-            wait_for_completion=False,               
-            conf={"source": "news_crawling_to_db_dag"},   
-        )
+        task_id="trigger_select_top5_and_save_dag",
+        trigger_dag_id="select_top5_and_save_dag",
+        reset_dag_run=True,
+        wait_for_completion=False,
+        conf={"source": "news_crawling_to_db_dag"},
+    )
 
-    get_article_link_task >> build_content_df_task >> process_crawled_articles_task >> trigger_dag2
+    get_article_links >> upsert_articles_task >> trigger_dag2

--- a/airflow/dags/select_top5_and_save_dag.py
+++ b/airflow/dags/select_top5_and_save_dag.py
@@ -1,0 +1,70 @@
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from datetime import timedelta
+import pendulum
+
+tz = pendulum.timezone("Asia/Seoul")
+
+# 1. 상위 5개 기사 선정
+def task_select_top5_articles(**context):
+    from libs.news_article.db_update.article_final_selection import select_top5_articles, get_db_connection
+    db_conn = get_db_connection()
+    selected_articles = select_top5_articles(db_conn)
+    return selected_articles
+
+# 2. is_used 업데이트
+def task_update_is_used_for_selected(**context):
+    from libs.news_article.db_update.article_final_selection import update_is_used_for_selected, get_db_connection
+    ti = context["ti"]
+    selected_articles = ti.xcom_pull(key="return_value", task_ids="select_top5_articles")
+    article_ids = [a["article_id"] for a in selected_articles]
+    db_conn = get_db_connection()
+    update_is_used_for_selected(article_ids, db_conn)
+    return selected_articles
+
+# 3. 본문 크롤링
+def task_crawl_article_contents(**context):
+    from libs.news_article.db_update.article_final_selection import crawl_article_contents
+    ti = context["ti"]
+    selected_articles = ti.xcom_pull(key="return_value", task_ids="update_is_used")
+    urls = [a["url"] for a in selected_articles]
+    contents = crawl_article_contents(urls)
+    # contents는 urls 순서를 따르도록 구현되어 있다고 가정
+    paired = [{"article_id": a["article_id"], "content": c} for a, c in zip(selected_articles, contents)]
+    return paired
+
+# 4. 저장
+def task_save_selected_articles(**context):
+    from libs.news_article.db_update.article_final_selection import save_selected_articles, get_db_connection
+    ti = context["ti"]
+    paired = ti.xcom_pull(key="return_value", task_ids="crawl_article_contents")
+    db_conn = get_db_connection()
+    save_selected_articles(paired, db_conn)
+
+default_args = {"owner": "airflow", "retries": 1, "retry_delay": timedelta(minutes=5)}
+with DAG(
+    dag_id="select_top5_and_save_dag",
+    schedule=None,
+    start_date=tz.datetime(2025, 9, 1, 7, 30),
+    catchup=False,
+    default_args=default_args,
+    timezone=tz,
+) as dag:
+    select_top5_articles_task = PythonOperator(
+        task_id="select_top5_articles",
+        python_callable=task_select_top5_articles,
+    )
+    update_is_used_task = PythonOperator(
+        task_id="update_is_used",
+        python_callable=task_update_is_used_for_selected,
+    )
+    crawl_article_contents_task = PythonOperator(
+        task_id="crawl_article_contents",
+        python_callable=task_crawl_article_contents,
+    )
+    save_selected_articles_task = PythonOperator(
+        task_id="save_selected_articles",
+        python_callable=task_save_selected_articles,
+    )
+
+    select_top5_articles_task >> update_is_used_task >> crawl_article_contents_task >> save_selected_articles_task

--- a/airflow/dags/select_top5_and_save_dag.py
+++ b/airflow/dags/select_top5_and_save_dag.py
@@ -5,66 +5,71 @@ import pendulum
 
 tz = pendulum.timezone("Asia/Seoul")
 
-# 1. 상위 5개 기사 선정
+# 1) Articles에서 Top5 선정
 def task_select_top5_articles(**context):
-    from libs.news_article.db_update.article_final_selection import select_top5_articles, get_db_connection
-    db_conn = get_db_connection()
-    selected_articles = select_top5_articles(db_conn)
-    return selected_articles
+    from libs.news_article.db_update.article_final_selection import get_db_connection, select_top5_articles
+    conn = get_db_connection()
+    selected = select_top5_articles(conn)
+    return selected
 
-# 2. is_used 업데이트
-def task_update_is_used_for_selected(**context):
-    from libs.news_article.db_update.article_final_selection import update_is_used_for_selected, get_db_connection
+# 2) Article_Categories
+def task_ensure_categories_and_mapping(**context):
+    from libs.news_article.db_update.article_final_selection import get_db_connection, save_selected_articles
     ti = context["ti"]
-    selected_articles = ti.xcom_pull(key="return_value", task_ids="select_top5_articles")
-    article_ids = [a["article_id"] for a in selected_articles]
-    db_conn = get_db_connection()
-    update_is_used_for_selected(article_ids, db_conn)
-    return selected_articles
+    selected = ti.xcom_pull(key="return_value", task_ids="select_top5_articles")
+    conn = get_db_connection()
+    # 카테고리 upsert 및 매핑은 save_selected_articles에서 처리한다고 가정
+    save_selected_articles(selected, conn)
+    return selected
 
-# 3. 본문 크롤링
+# 3) 본문 크롤링 (선정된 5건만)
 def task_crawl_article_contents(**context):
     from libs.news_article.db_update.article_final_selection import crawl_article_contents
     ti = context["ti"]
-    selected_articles = ti.xcom_pull(key="return_value", task_ids="update_is_used")
-    urls = [a["url"] for a in selected_articles]
-    contents = crawl_article_contents(urls)
-    # contents는 urls 순서를 따르도록 구현되어 있다고 가정
-    paired = [{"article_id": a["article_id"], "content": c} for a, c in zip(selected_articles, contents)]
+    selected = ti.xcom_pull(key="return_value", task_ids="ensure_categories_and_mapping")
+    urls = [a["url"] for a in selected]
+    contents = crawl_article_contents(urls)  # 크롤러 재사용
+    # article_id와 매핑해서 다음 단계로 전달
+    paired = [{"article_id": a["article_id"], "url": a["url"], "category_name": a["category_name"], "content": c}
+              for a, c in zip(selected, contents)]
     return paired
 
-# 4. 저장
-def task_save_selected_articles(**context):
-    from libs.news_article.db_update.article_final_selection import save_selected_articles, get_db_connection
+# 4) Selected_Articles 스냅샷 저장 + Articles.is_used=1 업데이트
+def task_save_selected_snapshot(**context):
+    from libs.news_article.db_update.article_final_selection import get_db_connection, save_selected_articles, update_is_used_for_selected
     ti = context["ti"]
     paired = ti.xcom_pull(key="return_value", task_ids="crawl_article_contents")
-    db_conn = get_db_connection()
-    save_selected_articles(paired, db_conn)
+    conn = get_db_connection()
+    # save_selected_articles: Selected_Articles(article_id, serving_date, url, category_name(JSON), title, sub_col(JSON), content_col(JSON), author, publish_time) insert
+    save_selected_articles(paired, conn)
+    ids = [p["article_id"] for p in paired]
+    update_is_used_for_selected(ids, conn)
 
 default_args = {"owner": "airflow", "retries": 1, "retry_delay": timedelta(minutes=5)}
+
 with DAG(
     dag_id="select_top5_and_save_dag",
-    schedule=None,
+    schedule=None,  # DAG1에서만 트리거
     start_date=tz.datetime(2025, 9, 1, 7, 30),
     catchup=False,
     default_args=default_args,
     timezone=tz,
 ) as dag:
-    select_top5_articles_task = PythonOperator(
+    select_top5_articles = PythonOperator(
         task_id="select_top5_articles",
         python_callable=task_select_top5_articles,
     )
-    update_is_used_task = PythonOperator(
-        task_id="update_is_used",
-        python_callable=task_update_is_used_for_selected,
+    ensure_categories_and_mapping_task = PythonOperator(
+        task_id="ensure_categories_and_mapping",
+        python_callable=task_ensure_categories_and_mapping,
     )
     crawl_article_contents_task = PythonOperator(
         task_id="crawl_article_contents",
         python_callable=task_crawl_article_contents,
     )
-    save_selected_articles_task = PythonOperator(
-        task_id="save_selected_articles",
-        python_callable=task_save_selected_articles,
+    save_selected_snapshot_task = PythonOperator(
+        task_id="save_selected_snapshot",
+        python_callable=task_save_selected_snapshot,
     )
 
-    select_top5_articles_task >> update_is_used_task >> crawl_article_contents_task >> save_selected_articles_task
+    select_top5_articles >> ensure_categories_and_mapping_task >> crawl_article_contents_task >> save_selected_snapshot_task

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -15,3 +15,5 @@ alembic==1.13.2            # DB 마이그레이션 도구
 # Apache Airflow
 apache-airflow[postgres,google]==2.9.3 \
 --constraint https://raw.githubusercontent.com/apache/airflow/constraints-2.9.3/constraints-3.11.txt
+
+# pendulum>=2.0, <4.0


### PR DESCRIPTION
## 📌 개요
<!-- PR의 목적을 간단히 설명해주세요. -->
Airflow DAG의 스켈레톤 코드를 작성했습니다.

## ✨ 주요 변경 사항
<!-- PR의 주요 변경 사항을 작성해주세요. -->
- [x] `news_crawling_to_db_dag.py` 추가
  - 기사 링크 수집 (linkCrawling.py)
  - Articles 테이블 업서트
  - 완료 후 DAG2(select_top5_and_save_dag) 트리거
- [x] `select_top5_and_save_dag.py` 추가
  - Top5 기사 선정
  - 카테고리 업서트
  - 본문 크롤링
  - Selected_Articles 저장
  - Articles.is_used 업데이트
- [x] `requirements.txt`  
  - timezone 처리를 위해 `pendulum` 패키지 추가

## 🔍 관련 이슈
<!-- Jira 발행 티겟을 입력해주세요. -->
- [ON-55](https://yuwolxx.atlassian.net/browse/ON-55?atlOrigin=eyJpIjoiNTI2MjUwMmY5ZjYyNGNlN2JmOGM2NTgyOTM1YzhlNTgiLCJwIjoiaiJ9)

## 🙏 To Reviewers
<!-- 코드 이해를 위해 참고할 수 있는 자료나 팀원에게 전달할 내용 입력해주세요. -->
- 이번 PR은 스켈레톤 단계입니다.
- 일부 DB/크롤러 함수가 아직 구현 중이라 테스트는 불가합니다.
- DAG 내 태스크 간 데이터 전달(XCom)은 함수의 최종 구현을 가정한 임시 return 값을 기반으로 작성되었습니다. (후속 PR에서 실제 함수 구현에 맞게 조정 예정)
- DAG1에서 Articles만 적재, DAG2에서 Top5 본문+카테고리 저장이 분리된 구조가 적절한지 확인 부탁드립니다.
- 현재 작성된 DAG에 timezone 처리를 위해 pendulum 패키지 사용을 고려 중이며, requirements.txt에는 일단 주석으로만 추가해두었습니다.

## ⚠️ 추가 고려 사항
<!-- 성능, 보안, 호환성 등 특별히 주의할 점이 있다면 작성 -->
- 크롤링 실패/DB 적재 실패 시 재시도 및 예외 처리 로직 추가 예정입니다.
- 대용량 본문은 XCom 대신 DB/스토리지 경로만 전달하는 방식으로 관리하는 방안을 고려 중입니다.


[ON-55]: https://yuwolxx.atlassian.net/browse/ON-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 매일 07:00 KST에 자동으로 뉴스 링크를 수집·정제하고 데이터를 저장하는 워크플로우를 추가했습니다.
  - 선택된 상위 5개 기사를 기반으로 카테고리 반영, 본문 수집, 스냅샷 저장까지 수행하는 수동 실행 파이프라인을 추가했습니다.
  - 두 워크플로우가 연동되어 최신 기사 처리와 후속 작업이 자동으로 이어집니다.
- 기타
  - 의존성 파일에 주석을 정리하여 가독성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->