### PR TITLE
[ON-24] fix/Articles Table 'serving_date' column 추가

### DIFF
--- a/airflow/dags/libs/news_article/db_update/article_final_selection.py
+++ b/airflow/dags/libs/news_article/db_update/article_final_selection.py
@@ -107,9 +107,11 @@ def insert_content(article_id, article_content):
             upsert=True
         )
 
+        serving_date = datetime.now().strftime("%Y-%m-%d")
+
         # === (2) MySQL is_used 업데이트 ===
         cursor = db_conn.cursor()
-        cursor.execute("UPDATE Articles SET is_used = 1 WHERE article_id = %s", (article_id,))
+        cursor.execute("UPDATE Articles SET is_used = 1, serving_date = %s WHERE article_id = %s", (serving_date, article_id,))
         db_conn.commit()
 
         print(f"[✅ SUCCESS] MongoDB 저장 + MySQL 업데이트 완료 (article_id={article_id})")

--- a/db_init/db_initialize.sql
+++ b/db_init/db_initialize.sql
@@ -13,6 +13,7 @@ CREATE TABLE Articles (
     dup_cnt INT DEFAULT 1,
     ordering DECIMAL(10, 1) NOT NULL, -- 기존 'order'에서 ordering으로 수정
     is_used TINYINT(1) DEFAULT 0, 
+    serving_date DATE DEFAULT NULL,
     UNIQUE KEY uk_url (url(767)) -- TEXT 컬럼의 UNIQUE 제약조건을 위한 인덱스
 );
 


### PR DESCRIPTION
## 📌 개요
MySQL > oba_article DB > Articles Table에 serving_date 컬럼을 추가했습니다.

## ✨ 주요 변경 사항
- [x] serving_date 컬럼 추가
- [x] airflow > dags > libs > news_article > db_update > article_final_selection.py 파일 내 RDS 업데이트 쿼리 수정

## 🔍 관련 이슈
<!-- Jira 발행 티겟을 입력해주세요. -->
- [ON-24](https://yuwolxx.atlassian.net/issues/?jql=project%20%3D%20%22ON%22%20AND%20component%20%3D%20%22Data%20Platform%22&selectedIssue=ON-24)

## 🙏 To Reviewers
  - EC2 환경에서 Airflow 실행 후 RDS의 serving_date가 수정되는지 확인 부탁드립니다.

[ON-24]: https://yuwolxx.atlassian.net/browse/ON-24?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 기사 서빙 날짜 추적 기능 추가
  * 기사 사용 시 현재 날짜가 자동으로 기록
  * 데이터 저장소 간 서빙 날짜 정보 일관성 강화로 데이터 무결성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->