### PR TITLE
[ON-102] DAG 분리 및 retry 설정 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,10 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         tzdata ca-certificates curl unzip wget build-essential \
     && rm -rf /var/lib/apt/lists/*
-<<<<<<< HEAD
 
 ENV TZ=Asia/Seoul
 
 # (중요) root에서 airflow로 전환한 뒤 pip install 해야 함!
-=======
-
-ENV TZ=Asia/Seoul
->>>>>>> 80d6bd9104bd2dbd985a5f091f4f6752621d10b5
 USER airflow
 
 # ======== AWS tools (S3 logging 위해 필요) ========

--- a/airflow/dags/news_crawling_to_db_dag.py
+++ b/airflow/dags/news_crawling_to_db_dag.py
@@ -20,12 +20,12 @@ def task_upsert_articles(**context):
     links = ti.xcom_pull(key="return_value", task_ids="get_article_links") # XCom에 저장된 데이터 받아오기
     process_crawled_articles(links)
 
-default_args = {"owner": "airflow", "retries": 1, "retry_delay": timedelta(minutes=5)}
+default_args = {"owner": "airflow", "retries": 2, "retry_delay": timedelta(minutes=30)}
 
 with DAG(
     dag_id="news_crawling_to_db_dag",
     schedule_interval="0 7 * * *",   # 매일 오전 7시 실행
-    start_date=pendulum.datetime(2025, 9, 1, 7, 30, tz=local_tz),
+    start_date=pendulum.datetime(2025, 9, 1, 7, 0, tz=local_tz),
     catchup=False,
     default_args=default_args,
 ) as dag:
@@ -39,11 +39,5 @@ with DAG(
         task_id="upsert_articles",
         python_callable=task_upsert_articles,
     )
-    trigger_dag2 = TriggerDagRunOperator(
-        task_id="trigger_select_top5_and_save_dag",
-        trigger_dag_id="select_top5_and_save_dag",
-        reset_dag_run=True,
-        wait_for_completion=False,
-    )
 
-    get_article_links >> upsert_articles >> trigger_dag2
+    get_article_links >> upsert_articles

--- a/airflow/dags/select_top5_and_save_dag.py
+++ b/airflow/dags/select_top5_and_save_dag.py
@@ -4,6 +4,7 @@ from airflow.operators.python import PythonOperator
 from datetime import timedelta
 import pendulum
 
+local_tz = pendulum.timezone("Asia/Seoul")
 
 def task_select_top5_articles(**context):
     from libs.news_article.db_update.article_final_selection import select_top5_articles
@@ -18,12 +19,12 @@ def task_crawl_and_save_contents(**context):
         content = get_content(article["url"])
         insert_content(article["article_id"], content)
 
-default_args = {"owner": "airflow", "retries": 1, "retry_delay": timedelta(minutes=5)}
+default_args = {"owner": "airflow", "retries": 2, "retry_delay": timedelta(minutes=10)}
 
 with DAG(
     dag_id="select_top5_and_save_dag",
-    schedule_interval=None,
-    start_date=pendulum.datetime(2025, 9, 1, tz="Asia/Seoul"),
+    schedule_interval="0 9 * * *",
+    start_date=pendulum.datetime(2025, 9, 1, 9, 0, tz=local_tz),
     catchup=False,
     default_args=default_args,
 ) as dag:


### PR DESCRIPTION
## 📌 개요
<!-- PR의 목적을 간단히 설명해주세요. -->
뉴스 기사 수집 DAG와 기사 선정 DAG의 의존 구조를 분리했습니다.

## ✨ 주요 변경 사항
<!-- PR의 주요 변경 사항을 작성해주세요. -->
- [x] DAG2를 독립 스케줄 실행 방식으로 변경
- [x] DAG1 retry 정책 조정 (retries=2, retry_delay=30분)
- [x] DAG2 실행 시간을 오전 9시로 조정하여 DAG1 재시도 및 DB 반영 시간 확보

## 🔍 관련 이슈
<!-- Jira 발행 티겟을 입력해주세요. -->
- [ON-102](https://yuwolxx.atlassian.net/browse/ON-102?atlOrigin=eyJpIjoiMDhkNTM2MTRmYjM2NDliMmJlMjYwYzY1MzQ5MjRlNWYiLCJwIjoiaiJ9)

## 🙏 To Reviewers
<!-- 코드 이해를 위해 참고할 수 있는 자료나 팀원에게 전달할 내용 입력해주세요. -->
  - 기존에는 DAG1 실패 시 DAG2까지 실행되지 않아, 당일 기사 수집 실패가 곧 추천 기사 미생성으로 이어지는 문제가 있었습니다.
  - DAG1은 매일 오전 7시, DAG2는 매일 오전 9시에 각각 독립적으로 실행됩니다.
  - DAG2는 이제 DAG1 성공 여부와 무관하게 실행되므로, DB에 저장된 기사 기준으로 Top5 선정이 가능합니다.

[ON-102]: https://yuwolxx.atlassian.net/browse/ON-102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Dockerfile 충돌 마커를 병합하고 중복된 환경 변수를 제거했습니다.

## Chores
* 자동화된 작업의 재시도 정책을 강화하여 실패 시 더 많은 재시도 횟수와 더 긴 대기 시간을 제공합니다.
* 스케줄링 설정을 조정하고 작업 시작 시간을 변경했습니다.
* 워크플로우 간 트리거 메커니즘을 제거하여 작업 흐름을 단순화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->